### PR TITLE
Fixed Incompatible stack heights

### DIFF
--- a/FrogHelper/Entities/FrogBerryShard.cs
+++ b/FrogHelper/Entities/FrogBerryShard.cs
@@ -329,6 +329,8 @@ namespace FrogHelper.Entities {
                     cursor.EmitDelegate<Action<HashSet<EntityID>, EntityID, Strawberry>>((set, id, berry) => {
                         if(set != berry.SceneAs<Level>()?.Session.Strawberries) set.Add(id);
                     });
+                    // we are on the FrogBerryShard path and we are missing the return value from HashSet<EntityID> to pop, insert a dummy value.
+                    cursor.Emit(OpCodes.Ldc_I4_0);
 
                     cursor.MarkLabel(endLabel);
                 }

--- a/FrogHelper/Entities/FrogBerryShard.cs
+++ b/FrogHelper/Entities/FrogBerryShard.cs
@@ -320,7 +320,9 @@ namespace FrogHelper.Entities {
                     cursor.Emit(OpCodes.Brtrue, shardLabel);
 
                     //If no: execute regular code, then go to end
-                    cursor.Index++;
+                    // we want to jump over the callvirt and the pop
+                    cursor.Index += 2;
+
                     cursor.Emit(OpCodes.Br, endLabel);
 
                     //If yes: check passed set, and only add if it's not the strawberry one
@@ -329,8 +331,6 @@ namespace FrogHelper.Entities {
                     cursor.EmitDelegate<Action<HashSet<EntityID>, EntityID, Strawberry>>((set, id, berry) => {
                         if(set != berry.SceneAs<Level>()?.Session.Strawberries) set.Add(id);
                     });
-                    // we are on the FrogBerryShard path and we are missing the return value from HashSet<EntityID> to pop, insert a dummy value.
-                    cursor.Emit(OpCodes.Ldc_I4_0);
 
                     cursor.MarkLabel(endLabel);
                 }


### PR DESCRIPTION
This mod craches on the latest core version due to invalid IL, currently if `CollectRoutineModifier` creates invalid IL, due to missing value on the stack on the `FrogBerryShard` path. This PR fixes it by jumping over the pop instruction.

For more info: https://discord.com/channels/403698615446536203/1143582725954080798